### PR TITLE
Add and build sensorfw suport

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -14,7 +14,9 @@ Build-Depends: debhelper (>= 9),
                qtbase5-private-dev (>= 5.9.5+dfsg~),
                qtdeclarative5-private-dev (>= 5.9.5~),
                xauth,
-               xvfb
+               xvfb,
+               pkg-config,
+               libsensorfw-qt5-dev
 Standards-Version: 4.1.1
 Homepage: http://qt-project.org/
 Vcs-Git: https://anonscm.debian.org/git/pkg-kde/qt/qtsensors.git
@@ -30,6 +32,17 @@ Description: Qt Sensors module
  is its rich set of widgets that provide standard GUI functionality.
  .
  This package contains Qt Sensors module.
+
+Package: libqt5sensors5-sensorfw
+Architecture: any
+Multi-Arch: same
+Pre-Depends: ${misc:Pre-Depends}
+Depends: ${misc:Depends}, ${shlibs:Depends}
+Description: Qt Sensors sensorfw plugin
+ Qt is a cross-platform C++ application framework. Qt's primary feature
+ is its rich set of widgets that provide standard GUI functionality.
+ .
+ This package contains Qt Sensors sensorfw plugin.
 
 Package: qml-module-qtsensors
 Architecture: any

--- a/debian/libqt5sensors5-sensorfw.install
+++ b/debian/libqt5sensors5-sensorfw.install
@@ -1,0 +1,2 @@
+usr/lib/*/qt5/plugins/sensors/libqtsensors_sensorfw.so
+etc/xdg/QtProject/Sensors.conf

--- a/debian/patches/build-sensorfw-and-linux.patch
+++ b/debian/patches/build-sensorfw-and-linux.patch
@@ -1,0 +1,13 @@
+Index: qtsensors-opensource-src-5.9.5/src/plugins/sensors/sensors.pro
+===================================================================
+--- qtsensors-opensource-src-5.9.5.orig/src/plugins/sensors/sensors.pro
++++ qtsensors-opensource-src-5.9.5/src/plugins/sensors/sensors.pro
+@@ -6,7 +6,7 @@ android {
+ }
+ 
+ qtConfig(sensorfw) {
+-    isEmpty(SENSORS_PLUGINS): SENSORS_PLUGINS = sensorfw generic
++    isEmpty(SENSORS_PLUGINS): SENSORS_PLUGINS = sensorfw linux iio-sensor-proxy generic
+ }
+ 
+ darwin {

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,1 +1,2 @@
 disable_local_tests.diff
+build-sensorfw-and-linux.patch

--- a/debian/rules
+++ b/debian/rules
@@ -20,7 +20,7 @@ pkgs_with_os = $(patsubst debian/%.install-$(DEB_HOST_ARCH_OS),%,$(wildcard debi
 	dh $@ --parallel --with pkgkde_symbolshelper
 
 override_dh_auto_configure:
-	qmake QT_BUILD_PARTS+=tests
+	qmake QT_BUILD_PARTS+=tests CONFIG+=sensorfw
 
 override_dh_auto_build-indep:
 	dh_auto_build -Smakefile -- docs


### PR DESCRIPTION
This does include a kinda nasty quilt patch to be able to build both sensorfw and linux at the same time, this should not be a big issue tough.

This does not change anything on the current system, it just adds sensorfw package to our repos. 